### PR TITLE
✨ String Segment Starts With String Segment Extension Method

### DIFF
--- a/src/Candoumbe.MiscUtilities/Candoumbe.MiscUtilities.csproj
+++ b/src/Candoumbe.MiscUtilities/Candoumbe.MiscUtilities.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\core.props" />
+    <Import Project="..\..\core.props"/>
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <Description>Usefull extension methods for collections/string/dictionary manipulation</Description>
@@ -15,9 +15,20 @@
     <PropertyGroup>
         <DefineConstants>$(DefineConstants);SYSTEM_TEXT;STRING_SEGMENT</DefineConstants>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Primitives" Version="9.0.0" />
-    </ItemGroup>
+
+    <Choose>
+        <When Condition="'$(TargetFramework)' == 'net9.0'">
+            <ItemGroup>
+                <PackageReference Include="System.Text.Json" Version="9.0.0"/>
+                <PackageReference Include="Microsoft.Extensions.Primitives" Version="9.0.0"/>
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup>
+                <PackageReference Include="System.Text.Json" Version="8.0.5"/>
+                <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0"/>
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
 
 </Project>

--- a/src/Candoumbe.MiscUtilities/StringSegmentExtensions.cs
+++ b/src/Candoumbe.MiscUtilities/StringSegmentExtensions.cs
@@ -228,5 +228,36 @@ namespace Microsoft.Extensions.Primitives
             TextInfo textInfo = cultureInfo?.TextInfo ?? CultureInfo.CurrentCulture.TextInfo;
             return textInfo.ToTitleCase(input.Value);
         }
+
+
+        /// <summary>
+        /// Determines if <paramref name="input"/> starts with <paramref name="search"/>.
+        /// </summary>
+        /// <param name="input">The string segment to test</param>
+        /// <param name="search"></param>
+        /// <param name="stringComparison"></param>
+        /// <returns></returns>
+        public static bool StartsWith(this StringSegment input, ReadOnlySpan<char> search, StringComparison stringComparison = default)
+        {
+            bool startsWith = false;
+
+            if (search.Length == 0)
+            {
+                startsWith = true;
+            }
+            else if(search.Length < input.Length)
+            {
+                int i = 0;
+                bool mismatchFound;
+                do
+                {
+                    mismatchFound = input[i] != search[i];
+                    i++;
+                } while (!mismatchFound && i < search.Length);
+
+                startsWith = !mismatchFound;
+            }
+            return startsWith;
+        }
     }
 }

--- a/test/Candoumbe.MiscUtilities.UnitTests/StringSegmentExtensionsTests.cs
+++ b/test/Candoumbe.MiscUtilities.UnitTests/StringSegmentExtensionsTests.cs
@@ -44,7 +44,7 @@ namespace Candoumbe.MiscUtilities.UnitTests
                 },
                 {
                     new StringSegment("zsasz"),
-                    new StringSegment("z"), 
+                    new StringSegment("z"),
                     (occurrences =>
                         occurrences != null
                         && occurrences.Exactly(2)


### PR DESCRIPTION
### 🚨 Breaking changes
• Dropped netstandard1.0%2C netstandard1.1 and net6.0 support ([#272](https://github.com/candoumbe/MiscUtilities/issues/272))
  • Removed DateOnlyJsonConverter%2C TimeOnlyJsonConverter
  • Removed T[] Enum.GetValues<T>() extension method
### 🧹 Housekeeping
• Removed Nuke.Common dependency
• Updated Candoumbe.Pipelines to 0.12.1

Full changelog at https://github.com/candoumbe/MiscUtilities/blob/feature/string-segment-starts-with-string-segment-extension-method/CHANGELOG.md