### PR TITLE
✨ Make Occurrences Work For Readonlyspan And Readonlymemory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 New features
-- Added various extension method to `ReadOnlyMemory<T>`.
+- Added `ReadOnlyMemoryExtensions.Occurrences(ReadOnlySpan<T> search)` extension method.
+- Added `ReadOnlyMemoryExtensions.FirstOccurrence(ReadOnlySpan<T> search)` extension method.
+- Added `ReadOnlyMemoryExtensions.LastOccurrence(ReadOnlySpan<T> search)` extension method.
+- Added `ReadOnlyMemoryExtensions.Split(ReadOnlySpan<T> search)` extension method.
 
 ### 🚨 Breaking changes
 - Dropped `netstandard1.0`, `netstandard1.1` and `net6.0` support ([#272](https://github.com/candoumbe/MiscUtilities/issues/272))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🚀 New features
+- Added various extension method to `ReadOnlyMemory<T>`.
+
 ### 🚨 Breaking changes
 - Dropped `netstandard1.0`, `netstandard1.1` and `net6.0` support ([#272](https://github.com/candoumbe/MiscUtilities/issues/272))
   - Removed `DateOnlyJsonConverter`, `TimeOnlyJsonConverter`

--- a/src/Candoumbe.MiscUtilities/ReadOnlyMemoryExtensions.cs
+++ b/src/Candoumbe.MiscUtilities/ReadOnlyMemoryExtensions.cs
@@ -1,0 +1,203 @@
+﻿// "Copyright (c) Cyrille NDOUMBE.
+// Licenced under GNU General Public Licence, version 3.0"
+
+namespace Microsoft.Extensions.Primitives
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq.Expressions;
+
+    /// <summary>
+    /// Provides extension methods for ReadOnlyMemory&lt;char&gt; type to perform string operations like finding occurrences,
+    /// checking start patterns and searching for substrings. Includes methods for finding first/last occurrences
+    /// and all occurrences of characters or character sequences.
+    /// </summary>
+    /// <remarks>
+    /// The class contains optimized methods for string searching and pattern matching operations
+    /// while working with <see cref="ReadOnlyMemory{T}"/> instances.
+    /// </remarks>
+    public static class ReadOnlyMemoryExtensions
+    {
+        /// <summary>
+        /// Reports all zero-based indexes of all occurrences of <paramref name="search"/> in the <paramref name="input"/>
+        /// </summary>
+        /// <param name="input">The <see cref="StringSegment"/> where searching occurrences will be performed</param>
+        /// <param name="search">The searched element</param>
+        /// <returns>
+        /// A collection of all indexes in <paramref name="input"/> where <paramref name="search"/> is present.
+        /// </returns>
+        /// <remarks>
+        ///     The returned collection should not be expected to be in any particular order.
+        /// </remarks>
+        public static IEnumerable<int> Occurrences(this ReadOnlyMemory<char> input, char search)
+        {
+            int i = 0;
+
+            if (input.IsEmpty)
+            {
+                yield break;
+            }
+
+            while (i < input.Length)
+            {
+                if (input.Span[i] == search)
+                {
+                    yield return i;
+                }
+
+                i++;
+            }
+        }
+                
+        /// <summary>
+        /// Reports the zero-based index of the first occurrence of a character span within the source span.
+        /// </summary>
+        /// <param name="source">The source to search within</param>
+        /// <param name="search">The character span to search for</param>
+        /// <param name="comparison">The type of string comparison to use. Defaults to StringComparison.InvariantCultureIgnoreCase</param>
+        /// <returns>
+        /// The index where the search span was first found in the source, or -1 if no occurrence was found.
+        /// If the search span is empty, returns 0.
+        /// </returns>
+        /// </summary>
+        public static int FirstOccurrence(this ReadOnlyMemory<char> source, ReadOnlySpan<char> search, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            int index;
+            if (search.IsEmpty)
+            {
+                index = 0;
+            }
+            else
+            {
+                using IEnumerator<int> enumerator = source.Occurrences(search.ToArray(), comparison)
+                    .GetEnumerator();
+
+                index =  enumerator.MoveNext()
+                    ? enumerator.Current
+                    : -1;
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Report a zero-based index of the last occurrence of <paramref name="search"/> span within <paramref name="source"/> span.
+        /// </summary>
+        /// <param name="source">The source to search within</param>
+        /// <param name="search">The character span to search for</param>
+        /// <returns>
+        /// the index where <paramref name="search"/>
+        /// was found in <paramref name="source"/> or <c>-1</c> if no occurrence found
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when source is null</exception>
+        public static int LastOccurrence(this ReadOnlyMemory<char> source, ReadOnlySpan<char> search, StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            bool found = false;
+            int index = -1,
+                offset = 0;
+
+            if (source.IsEmpty)
+            {
+                if (search.IsEmpty)
+                {
+                    index = 0;
+                }
+            }
+            else if (search.IsEmpty)
+            {
+                index = source is { Length: > 0 } memory ? memory.Length - 1 : 0;
+            }
+            else if (source.Length >= search.Length)
+            {
+                int currentPos = source.Span.LastIndexOf(search[0]);
+                int remainingCharactersInSource = source.Length - currentPos;
+
+                if(remainingCharactersInSource >= search.Length)
+                {
+                    while (!found && currentPos >= 0)
+                    {
+                        ReadOnlySpan<char> subSegment = source.Slice(currentPos, search.Length).Span;
+                        found = subSegment.Equals(search, stringComparison);
+                        if (found)
+                        {
+                            index = currentPos;
+                        }
+
+                        offset++;
+                        currentPos = source.Length - (search.Length + offset);
+                    }
+                }
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Reports all zero-based indexes of all occurrences of <paramref name="search"/> in the <paramref name="input"/>
+        /// </summary>
+        /// <param name="input">The <see cref="StringSegment"/> where searching occurrences will be performed</param>
+        /// <param name="search">The searched element</param>
+        /// <param name="stringComparison"></param>
+        /// <returns>
+        /// A collection of all indexes in <paramref name="input"/> where <paramref name="search"/> is present.
+        /// </returns>
+        public static IEnumerable<int> Occurrences(this ReadOnlyMemory<char> input, ReadOnlyMemory<char> search, StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            int currentPos = 0;
+
+            if (search.IsEmpty)
+            {
+                yield return 0;
+            }
+
+            if (input.IsEmpty || input.Length < search.Length)
+            {
+                yield break;
+            }
+
+            int inputLength = input.Length;
+            int index;
+            do
+            {
+                index = input.Slice(currentPos).Span.IndexOf(search.Span, stringComparison);
+                if (index != -1)
+                {
+                    yield return index + currentPos;
+                }
+
+                int newPos = index + currentPos + search.Length;
+                currentPos = newPos + 1;
+            } while (currentPos < inputLength && index != -1);
+        }
+
+        /// <summary>
+        /// Determines if <paramref name="input"/> starts with <paramref name="search"/>.
+        /// </summary>
+        /// <param name="input">The <see cref="ReadOnlyMemory{T}"/> to test</param>
+        /// <param name="search">The value to </param>
+        /// <returns><see langword="true"/> when <paramref name="input"/> starts with the specified <paramref name="search"/> value of <see langword="false"/> otherwise.</returns>
+        public static bool StartsWith<T>(this ReadOnlyMemory<T> input, ReadOnlySpan<T> search)
+        {
+            bool startsWith = false;
+
+            if (search.Length == 0)
+            {
+                startsWith = true;
+            }
+            else if(search.Length < input.Length)
+            {
+                int i = 0;
+                bool mismatchFound;
+                do
+                {
+                    mismatchFound =  !input.Span[i].Equals(search[i]);
+                    i++;
+                } while (!mismatchFound && i < search.Length);
+
+                startsWith = !mismatchFound;
+            }
+            return startsWith;
+        }
+    }
+}

--- a/test/Candoumbe.MiscUtilities.UnitTests/ReadOnlyMemoryExtensionsTests.cs
+++ b/test/Candoumbe.MiscUtilities.UnitTests/ReadOnlyMemoryExtensionsTests.cs
@@ -1,0 +1,281 @@
+﻿// "Copyright (c) Cyrille NDOUMBE.
+// Licenced under GNU General Public Licence, version 3.0"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+namespace Candoumbe.MiscUtilities.UnitTests
+{
+    [UnitTest]
+    public class ReadOnlyMemoryExtensionsTests(ITestOutputHelper outputHelper)
+    {
+        private readonly ITestOutputHelper _outputHelper = outputHelper;
+
+        public static TheoryData<ReadOnlyMemory<char>, ReadOnlyMemory<char>, Expression<Func<IEnumerable<int>, bool>>, string> OccurrencesCases
+            => new()
+            {
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("z"),
+                    occurrences => occurrences != null && !occurrences.Any(),
+                    "There's no occurrence of the search element in the string"
+                },
+                {
+                    StringSegment.Empty, new StringSegment("z"),
+                    (occurrences => occurrences != null && !occurrences.Any()),
+                    "The source element is empty"
+                },
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("F"),
+                    (occurrences => occurrences != null
+                                    && occurrences.Exactly(1)
+                                    && occurrences.Once(pos => pos == 0)
+                    ),
+                    "There is one occurrence of the search element in the string"
+                },
+                {
+                    new StringSegment("zsasz"),
+                    new StringSegment("z"),
+                    occurrences => occurrences != null
+                        && occurrences.Exactly(2)
+                        && occurrences.Once(pos => pos == 0)
+                        && occurrences.Once(pos => pos == 4)
+                    ,
+                    "There is 2 occurrences of the search element in the string"
+                }
+            };
+
+        [Theory]
+        [MemberData(nameof(OccurrencesCases))]
+        public void Occurrences(ReadOnlyMemory<char> source, ReadOnlyMemory<char> search, Expression<Func<IEnumerable<int>, bool>> expectation, string reason)
+        {
+            _outputHelper.WriteLine($"Source : '{source.Span}'");
+            _outputHelper.WriteLine($"Search : '{search}'");
+
+            // Act
+            IEnumerable<int> occurrences = source.Occurrences(search);
+
+            _outputHelper.WriteLine($"Result : {occurrences.Jsonify()}");
+
+            // Assert
+            occurrences.Should()
+                       .Match(expectation, reason);
+        }
+
+        public static TheoryData<ReadOnlyMemory<char>, char, Expression<Func<IEnumerable<int>, bool>>, string> OccurrencesWithCharCases
+            => new()
+            {
+                {
+                    new StringSegment("Firstname"),
+                    'z',
+                    occurrences => occurrences != null && occurrences.None(),
+                     "There's no occurrence of the search element in the string"
+                },
+                {
+                    StringSegment.Empty,
+                    'z',
+                    occurrences => occurrences != null && occurrences.None(),
+                    "There source is empty"
+                },
+                {
+                    new StringSegment("Firstname"),
+                    'F',
+                    occurrences => occurrences != null
+                        && occurrences.Exactly(1)
+                        && occurrences.Once(pos  => pos == 0),
+                    "There is one occurrence of the search element in the string"
+                },
+                {
+                    new StringSegment("zsasz"),
+                    'z',
+                    occurrences => occurrences != null && occurrences.Exactly(2)
+                        && occurrences.Once(pos => pos == 0)
+                        && occurrences.Once(pos  =>pos == 4),
+                    "There is 2 occurrences of the search element in the string"
+                }
+        };
+
+        [Theory]
+        [MemberData(nameof(OccurrencesWithCharCases))]
+        public void Occurrences_of_char(ReadOnlyMemory<char> source, char search, Expression<Func<IEnumerable<int>, bool>> expectation, string reason)
+        {
+            _outputHelper.WriteLine($"Source : '{source.Span}'");
+            _outputHelper.WriteLine($"Search : '{search}'");
+
+            // Act
+            IEnumerable<int> occurrences = source.Occurrences(search);
+
+            _outputHelper.WriteLine($"Result : {occurrences.Jsonify()}");
+
+            // Assert
+            occurrences.Should()
+                       .Match(expectation, reason);
+        }
+
+        public static TheoryData<ReadOnlyMemory<char>, ReadOnlyMemory<char>, StringComparison, int, string> LastOccurrenceCases
+        => new()
+            {
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("z"),
+                    StringComparison.OrdinalIgnoreCase,
+                    -1,
+                    "There's no occurrence of the search element in the string"
+                },
+                {
+                    StringSegment.Empty,
+                    new StringSegment("z"),
+                    StringComparison.OrdinalIgnoreCase,
+                    -1,
+                    "The source element is empty"
+                },
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("F"),
+                    StringComparison.OrdinalIgnoreCase,
+                    0,
+                    "There is one occurrence of the search element in the string"
+                },
+                {
+                    new StringSegment("zsasz"),
+                    new StringSegment("z"),
+                    StringComparison.OrdinalIgnoreCase,
+                    4,
+                    "There is 2 occurrences of the search element in the string"
+                }
+            };
+
+        [Theory]
+        [MemberData(nameof(LastOccurrenceCases))]
+        public void LastOccurrence(ReadOnlyMemory<char> source, ReadOnlyMemory<char> search, StringComparison stringComparison, int expectation, string reason)
+        {
+            // Act
+            int actual = source.LastOccurrence(search.Span, stringComparison);
+
+            // Assert
+            actual.Should()
+                  .Be(expectation, reason);
+        }
+
+        [Property]
+        public void Given_source_is_not_null_When_search_is_empty_Then_LastOccurrence_returns_the_length_of_the_source(NonNull<string> sourceGenerator)
+        {
+            // Arrange
+            StringSegment source = sourceGenerator.Item;
+
+            // Act
+            int lastIndex =  source.LastOccurrence(StringSegment.Empty);
+
+            // Assert
+            _ = source.Length switch
+            {
+                > 0 => lastIndex.Should().Be(source.Length - 1),
+                _ => lastIndex.Should().Be(0),
+            };
+        }
+
+        public static TheoryData<ReadOnlyMemory<char>, ReadOnlyMemory<char>, StringComparison, int> FirstOccurrenceCases
+            => new()
+            {
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("z"),
+                    StringComparison.OrdinalIgnoreCase,
+                    -1
+                },
+                {
+                    StringSegment.Empty,
+                    new StringSegment("z"),
+                    StringComparison.OrdinalIgnoreCase,
+                    -1
+                },
+                {
+                    StringSegment.Empty,
+                    StringSegment.Empty,
+                    StringComparison.OrdinalIgnoreCase,
+                    0
+                },
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("F"),
+                    StringComparison.OrdinalIgnoreCase,
+                    0
+                },
+                {
+                    new StringSegment("zsasz"),
+                    new StringSegment("z"),
+                    StringComparison.OrdinalIgnoreCase,
+                    0
+                }
+            };
+
+        [Theory]
+        [MemberData(nameof(FirstOccurrenceCases))]
+        public void FirstOccurrence(ReadOnlyMemory<char> source, ReadOnlyMemory<char> search, StringComparison stringComparison, int expected)
+        {
+            // Act
+            int actual = source.FirstOccurrence(search.ToArray(), stringComparison);
+
+            // Assert
+            actual.Should()
+                  .Be(expected);
+        }
+
+        public static TheoryData<ReadOnlyMemory<char>, ReadOnlyMemory<char>, bool> StartsWithCases
+            => new()
+            {
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("z"),
+                    false
+                },
+                {
+                    StringSegment.Empty,
+                    new StringSegment("z"),
+                    false
+                },
+                {
+                    StringSegment.Empty,
+                    StringSegment.Empty,
+                    true
+                },
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("F"),
+                    true
+                },
+                {
+                    new StringSegment("Firstname"),
+                    new StringSegment("First"),
+                    true
+                },
+                {
+                    new StringSegment("zsasz"),
+                    new StringSegment("z"),
+                    true
+                }
+            };
+
+        [Theory]
+        [MemberData(nameof(StartsWithCases))]
+        public void StartsWith(ReadOnlyMemory<char> source, ReadOnlyMemory<char> search, bool expected)
+        {
+            // Act
+            bool actual = source.StartsWith(search.Span);
+
+            // Assert
+            actual.Should()
+                .Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
### 🚀 New features
• Added ReadOnlyMemoryExtensions.Occurrences(ReadOnlySpan<T> search) extension method.
• Added ReadOnlyMemoryExtensions.FirstOccurrence(ReadOnlySpan<T> search) extension method.
• Added ReadOnlyMemoryExtensions.LastOccurrence(ReadOnlySpan<T> search) extension method.
• Added ReadOnlyMemoryExtensions.Split(ReadOnlySpan<T> search) extension method.
### 🚨 Breaking changes
• Dropped netstandard1.0%2C netstandard1.1 and net6.0 support ([#272](https://github.com/candoumbe/MiscUtilities/issues/272))
  • Removed DateOnlyJsonConverter%2C TimeOnlyJsonConverter
  • Removed T[] Enum.GetValues<T>() extension method
### 🧹 Housekeeping
• Removed Nuke.Common dependency
• Updated Candoumbe.Pipelines to 0.12.1

Full changelog at https://github.com/candoumbe/MiscUtilities/blob/feature/make-occurrences-work-for-readonlyspan-and-readonlymemory/CHANGELOG.md